### PR TITLE
Handle code blocks in cloze input reveal

### DIFF
--- a/plus_ultra_cards/app/formatting/text_formatter.py
+++ b/plus_ultra_cards/app/formatting/text_formatter.py
@@ -438,11 +438,25 @@ class TextFormatter:
             token = f"__CLOZE_INPUT_TOKEN_{cloze_num}_{len(token_map)}__"
 
             if reveal:
-                # Show the answer with highlighting
-                html_replacement = f'<span class="cloze-input-revealed" data-cloze="{cloze_num}">{answer}</span>'
+                # Render the answer to HTML to support style markup without syntax highlighting
+                rendered_answer = self.render_to_html(answer, apply_syntax_highlighting=False)
+                # Detect if the rendered answer is a code block (<pre or <div> with class="code-block")
+                if re.match(r'\s*(?:<div class="code-block"[\s\S]*</div>|<pre class="code-block"[\s\S]*</pre>)\s*$', rendered_answer):
+                    # For code blocks, show the rendered block directly with no additional wrapping
+                    html_replacement = rendered_answer
+                else:
+                    # For normal text, wrap the rendered answer in brackets with no special background
+                    html_replacement = (
+                        f'<span class="cloze-input-revealed-answer" data-cloze="{cloze_num}">' 
+                        f'[{rendered_answer}]'
+                        '</span>'
+                    )
             else:
                 # Show input field for user interaction
-                html_replacement = f'<input type="text" class="cloze-input-field" data-cloze="{cloze_num}" data-answer="{answer}" placeholder="Type answer..." />'
+                html_replacement = (
+                    f'<input type="text" class="cloze-input-field" data-cloze="{cloze_num}" '
+                    f'data-answer="{answer}" placeholder="Type answer..." />'
+                )
 
             token_map[token] = html_replacement
 


### PR DESCRIPTION
## Summary
- Render revealed cloze input answers through HTML processing
- Skip cloze span wrapping for code-block answers
- Wrap non-code answers in bracket-only container for reveal mode

## Testing
- `pytest -q test_cloze_input_functionality.py test_cloze_input_integration.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6'; ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68bb8c0aa45c8324bd98da9961baf5e4