### PR TITLE
Centralize Win95 font loading and substitutions

### DIFF
--- a/plus_ultra_cards/app/core/card_templates.py
+++ b/plus_ultra_cards/app/core/card_templates.py
@@ -6,7 +6,8 @@ Provides retro-styled preset templates and custom template management.
 import json
 import os
 from typing import Dict, List
-from pathlib import Path
+
+from app.ui.font_loader import load_win95_font
 
 
 class CardTemplateManager:
@@ -42,8 +43,8 @@ class CardTemplateManager:
     
     def create_default_templates(self) -> Dict:
         """Create the default template - only Basic template with proper MS Sans Serif font."""
-        # Load the MS Sans Serif font explicitly to ensure it's available
-        self._ensure_ms_sans_serif_loaded()
+        # Load the Win95 font to ensure substitutions are set
+        load_win95_font()
 
         templates = {
             "Basic": {
@@ -60,36 +61,6 @@ class CardTemplateManager:
         self.save_templates()
         return templates
 
-    def _ensure_ms_sans_serif_loaded(self):
-        """Ensure MS Sans Serif font is loaded from the .otf file."""
-        try:
-            from PySide6.QtGui import QFontDatabase, QFont
-            from pathlib import Path
-
-            # Path to the MS Sans Serif font file
-            font_path = Path(__file__).resolve().parents[1] / "assets" / "fonts" / "W95font.otf"
-
-            if font_path.exists():
-                fid = QFontDatabase.addApplicationFont(str(font_path))
-                if fid != -1:
-                    families = QFontDatabase.applicationFontFamilies(fid)
-                    if families:
-                        loaded_family = families[0]
-                        # Set up font substitutions to ensure MS Sans Serif resolves correctly
-                        QFont.insertSubstitution("MS Sans Serif", loaded_family)
-                        QFont.insertSubstitution("Microsoft Sans Serif", loaded_family)
-                        # Also set up the reverse mapping
-                        QFont.insertSubstitution("W95font", loaded_family)
-                        print(f"MS Sans Serif font loaded successfully: {loaded_family}")
-                        return True
-
-            print("Warning: MS Sans Serif font file not found, using system fallback")
-            return False
-
-        except Exception as e:
-            print(f"Error loading MS Sans Serif font: {e}")
-            return False
-    
     def ensure_default_templates(self, templates: Dict):
         """Ensure default templates exist in the loaded templates."""
         defaults = self.create_default_templates()

--- a/plus_ultra_cards/app/ui/font_loader.py
+++ b/plus_ultra_cards/app/ui/font_loader.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+import logging
+from pathlib import Path
+from typing import Optional
+
+from PySide6.QtGui import QFont, QFontDatabase
+from PySide6.QtWidgets import QApplication
+
+logger = logging.getLogger(__name__)
+
+def load_win95_font(app: Optional[QApplication] = None, base_point_size: int = 9) -> Optional[str]:
+    """Load bundled Win95 font and set substitutions.
+
+    Parameters
+    ----------
+    app: QApplication, optional
+        If provided, the application's default font will be set.
+    base_point_size: int
+        Point size used when setting the application font.
+
+    Returns
+    -------
+    str | None
+        Name of the loaded (or fallback) font family.
+    """
+    font_file = "W95font.otf"
+    search_paths = [
+        Path(__file__).resolve().parents[1] / "assets" / "fonts" / font_file,
+        Path(__file__).resolve().parents[2] / "assets" / "fonts" / font_file,
+        Path.cwd() / "assets" / "fonts" / font_file,
+        Path.cwd() / font_file,
+        Path(__file__).resolve().parents[2] / font_file,
+    ]
+
+    loaded_family = None
+    for path in search_paths:
+        if path.exists():
+            fid = QFontDatabase.addApplicationFont(str(path))
+            if fid != -1:
+                families = QFontDatabase.applicationFontFamilies(fid)
+                if families:
+                    loaded_family = families[0]
+                    break
+
+    if loaded_family:
+        if app is not None:
+            app.setFont(QFont(loaded_family, base_point_size))
+        QFont.insertSubstitution("MS Sans Serif", loaded_family)
+        QFont.insertSubstitution("Microsoft Sans Serif", loaded_family)
+        QFont.insertSubstitution("Fixedsys", "Courier New")
+        return loaded_family
+
+    logger.warning("W95font.otf not found; using system fallback fonts.")
+    fallback_family = None
+    for family in ("Microsoft Sans Serif", "Tahoma", "Arial"):
+        if family in QFontDatabase().families():
+            fallback_family = family
+            if app is not None:
+                app.setFont(QFont(family, base_point_size))
+            break
+
+    if fallback_family:
+        QFont.insertSubstitution("MS Sans Serif", fallback_family)
+        QFont.insertSubstitution("Microsoft Sans Serif", fallback_family)
+    else:
+        fallback_family = "Arial"
+        if app is not None:
+            app.setFont(QFont(fallback_family, base_point_size))
+        QFont.insertSubstitution("MS Sans Serif", fallback_family)
+        QFont.insertSubstitution("Microsoft Sans Serif", fallback_family)
+
+    QFont.insertSubstitution("Fixedsys", "Courier New")
+    return fallback_family

--- a/plus_ultra_cards/app/ui/gui/api_key_dialog.py
+++ b/plus_ultra_cards/app/ui/gui/api_key_dialog.py
@@ -11,12 +11,13 @@ from pathlib import Path
 from typing import Dict, Any
 
 from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QFormLayout, QLineEdit, 
+    QDialog, QVBoxLayout, QHBoxLayout, QFormLayout, QLineEdit,
     QPushButton, QLabel, QTabWidget, QWidget, QTextEdit, QGroupBox,
     QCheckBox, QSpinBox, QComboBox, QMessageBox
 )
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QFont
+
+from app.ui.font_loader import load_win95_font
 
 
 class APIKeyDialog(QDialog):
@@ -262,14 +263,7 @@ class APIKeyDialog(QDialog):
     
     def apply_retro_styling(self):
         """Apply retro Win95 styling"""
-        font_path = Path("app/assets/W95Afont.otf")
-        if font_path.exists():
-            font_id = QFont.addApplicationFont(str(font_path))
-            if font_id != -1:
-                font_family = QFont.applicationFontFamilies(font_id)[0]
-                font = QFont(font_family, 9)
-                self.setFont(font)
-        
+        load_win95_font()
         # Apply retro color scheme
         self.setStyleSheet("""
             QDialog {

--- a/plus_ultra_cards/app/ui/gui/card_editor.py
+++ b/plus_ultra_cards/app/ui/gui/card_editor.py
@@ -19,6 +19,8 @@ from app.core.card_templates import CardTemplateManager
 from app.ui.enhanced_text_widgets import CodeEditorWidget, FormattedTextDisplay, CodeAwareTextEdit
 from app.ui.gui.widgets.scroll_label import ScrollableLabel
 
+from app.ui.font_loader import load_win95_font
+
 import re
 
 class CardEditorDialog(QDialog):
@@ -34,24 +36,8 @@ class CardEditorDialog(QDialog):
         self.setWindowTitle("Card Editor")
         self.resize(900, 700)
 
-        # Ensure Win95 font is loaded + substitution for legacy names in dialogs
-        try:
-            from PySide6.QtGui import QFontDatabase, QFont
-            from pathlib import Path
-            otf_path = Path(__file__).resolve().parents[2] / "assets" / "fonts" / "W95font.otf"
-            if otf_path.exists():
-                fid = QFontDatabase.addApplicationFont(str(otf_path))
-                if fid != -1:
-                    fams = QFontDatabase.applicationFontFamilies(fid)
-                    if fams:
-                        fam = fams[0]
-                        self.setFont(QFont(fam, 9))
-                        # Substitutions so CSS requests resolve
-                        QFont.insertSubstitution("MS Sans Serif", fam)
-                        QFont.insertSubstitution("Microsoft Sans Serif", fam)
-                        QFont.insertSubstitution("Fixedsys", "Courier New")
-        except Exception:
-            pass
+        # Ensure Win95 font substitutions are in place
+        load_win95_font()
 
         self.setup_ui()
         if card:

--- a/plus_ultra_cards/app/ui/gui/main_window.py
+++ b/plus_ultra_cards/app/ui/gui/main_window.py
@@ -18,6 +18,7 @@ from PySide6.QtWidgets import (
 
 # Import app components
 from app.ui.retro95 import apply_win95_theme, RetroSeparator, RetroMarquee
+from app.ui.font_loader import load_win95_font
 from app.core.card_manager import CardManager
 from app.core.study_sessions import SessionManager, StudyMode
 from app.core.deck_layout_manager import DeckLayoutManager
@@ -1124,7 +1125,8 @@ class MainWindow(QMainWindow):
 def main():
     """Main application entry point."""
     app = QApplication(sys.argv)
-    apply_win95_theme(app, base_point_size=10)
+    load_win95_font(app)
+    apply_win95_theme(app)
 
     window = MainWindow()
     window.show()

--- a/plus_ultra_cards/app/ui/retro95.py
+++ b/plus_ultra_cards/app/ui/retro95.py
@@ -5,7 +5,7 @@ import math, os, random, sys, time
 from pathlib import Path
 
 from PySide6.QtCore import Qt, QTimer, QPoint, QRect
-from PySide6.QtGui import (QAction, QColor, QCursor, QFont, QFontDatabase, QIcon,
+from PySide6.QtGui import (QAction, QColor, QCursor, QIcon,
                            QPainter, QPalette, QPixmap)
 from PySide6.QtCore import QSize
 from PySide6.QtGui import QIcon
@@ -17,6 +17,8 @@ from PySide6.QtWidgets import (
     QStatusBar, QStyle, QTabWidget, QTableWidget, QTableWidgetItem, QTextEdit,
     QToolBar, QTreeView, QVBoxLayout, QWidget
 )
+
+from .font_loader import load_win95_font
 
 # ---------------------- Win95 Palette + QSS ----------------------
 WIN95 = {
@@ -152,7 +154,8 @@ def vintage_icon(icon: QIcon, size: QSize, downscale: float = 0.9) -> QIcon:
     chunky = small.scaled(size, Qt.KeepAspectRatio, Qt.FastTransformation)
     return QIcon(chunky)
 
-def apply_win95_theme(app: QApplication, base_point_size: int = 9):
+def apply_win95_theme(app: QApplication):
+    """Apply Win95-style palette and styling."""
     # Palette (Fusion for consistent cross-platform look)
     app.setStyle("Fusion")
     pal = QPalette()
@@ -168,52 +171,6 @@ def apply_win95_theme(app: QApplication, base_point_size: int = 9):
     pal.setColor(QPalette.Highlight, QColor(WIN95["sel_bg"]))
     pal.setColor(QPalette.HighlightedText, QColor(WIN95["sel_text"]))
     app.setPalette(pal)
-
-    # Load Win95-style OTF and set substitutions for legacy names
-    ok = False
-    loaded_family = None
-
-    # Direct path to the font file in app/assets/fonts
-    font_path = Path(__file__).resolve().parent.parent / "assets" / "fonts" / "W95font.otf"
-
-    # Try the direct path first, then fallbacks
-    possible_paths = [
-        font_path,  # Direct path: app/assets/fonts/W95font.otf
-        Path(__file__).resolve().parents[1] / "assets" / "fonts" / "W95font.otf",  # app/assets/fonts
-        Path(__file__).resolve().parents[2] / "assets" / "fonts" / "W95font.otf",  # project-root/assets/fonts
-        Path.cwd() / "assets" / "fonts" / "W95font.otf",                           # cwd/assets/fonts
-        Path.cwd() / "W95font.otf",                                                    # cwd
-        Path(__file__).resolve().parents[2] / "W95font.otf",                           # project root
-    ]
-
-    for p in possible_paths:
-        if p.exists():
-            fid = QFontDatabase.addApplicationFont(str(p))
-            if fid != -1:
-                fams = QFontDatabase.applicationFontFamilies(fid)
-                if fams:
-                    loaded_family = fams[0]
-                    f = QFont(loaded_family, base_point_size)
-                    app.setFont(f)
-                    ok = True
-                    # Substitute legacy names to our bundled font
-                    QFont.insertSubstitution("MS Sans Serif", loaded_family)
-                    QFont.insertSubstitution("Microsoft Sans Serif", loaded_family)
-                    # For Fixedsys (monospace), map to Courier New if we don't bundle a fixed font
-                    QFont.insertSubstitution("Fixedsys", "Courier New")
-                    break
-
-    if not ok:
-        # Fallbacks (Windows has "Microsoft Sans Serif"); else Tahoma/Arial
-        for family in ("Microsoft Sans Serif", "Tahoma", "Arial"):
-            if family in QFontDatabase().families():
-                f = QFont(family, base_point_size)
-                app.setFont(f)
-                # Ensure legacy names resolve to an installed font to avoid DirectWrite errors
-                QFont.insertSubstitution("MS Sans Serif", family)
-                QFont.insertSubstitution("Microsoft Sans Serif", family)
-                QFont.insertSubstitution("Fixedsys", "Courier New")
-                break
 
     app.setStyleSheet(_QSS)
 
@@ -528,6 +485,7 @@ class Main(QMainWindow):
 # ---------------------- Main ----------------------
 if __name__ == "__main__":
     app = QApplication(sys.argv)
-    apply_win95_theme(app, base_point_size=11)  # loads W95FA.otf from same folder if present
+    load_win95_font(app, base_point_size=11)
+    apply_win95_theme(app)
     Main().show()
     sys.exit(app.exec())

--- a/plus_ultra_cards/main.py
+++ b/plus_ultra_cards/main.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 from PySide6.QtWidgets import QApplication, QMessageBox
 from app.ui.gui.main_window import MainWindow
 from app.ui.retro95 import apply_win95_theme
+from app.ui.font_loader import load_win95_font
 
 
 def check_dependencies():
@@ -97,10 +98,16 @@ def main():
     app.setApplicationName("Plus Ultra Cards")
     app.setApplicationVersion("1.0")
     app.setOrganizationName("Plus Ultra Cards")
-    
+
+    # Load Win95 font before any widgets are created
+    try:
+        load_win95_font(app, base_point_size=10)
+    except Exception as e:
+        print(f"Warning: Failed to load Win95 font: {e}")
+
     # Apply retro95 theme
     try:
-        apply_win95_theme(app, base_point_size=10)
+        apply_win95_theme(app)
     except Exception as e:
         print(f"Warning: Failed to apply retro95 theme: {e}")
     

--- a/plus_ultra_cards/ui/enhanced_text_widgets.py
+++ b/plus_ultra_cards/ui/enhanced_text_widgets.py
@@ -12,6 +12,7 @@ from PySide6.QtWidgets import (
 
 from app.formatting.formatter_service import FormatterService, RenderingOptions
 from app.formatting.text_formatter import TextFormatter as _TF_CSS
+from app.ui.font_loader import load_win95_font
 
 
 class CodeAwareTextEdit(QTextEdit):
@@ -123,22 +124,8 @@ class FormattedTextDisplay(QLabel):
         self.setTextFormat(Qt.RichText)
         self.setWordWrap(True)
         self.setAlignment(Qt.AlignTop | Qt.AlignLeft)
-        # Try to load bundled MS Sans Serif from assets (if present)
-        try:
-            from PySide6.QtGui import QFontDatabase
-            from pathlib import Path as _P
-            _assets = _P(__file__).resolve().parents[2] / "assets"
-            for cand in ["MS_Sans_Serif.ttf", "ms_sans_serif.ttf", "MS_Sans_Serif.otf"]:
-                fp = _assets / cand
-                if fp.exists():
-                    fid = QFontDatabase.addApplicationFont(str(fp))
-                    if fid != -1:
-                        fams = QFontDatabase.applicationFontFamilies(fid)
-                        if fams:
-                            self.setFont(QFont(fams[0], 10))
-                            break
-        except Exception:
-            pass
+
+        load_win95_font()
 
         self.setStyleSheet("""
             QLabel {


### PR DESCRIPTION
## Summary
- Add `font_loader.load_win95_font` utility to locate `W95font.otf`, register it with Qt, and provide fallbacks with logged warnings.
- Load Win95 font once at startup and simplify `apply_win95_theme` to palette/QSS duties.
- Replace scattered font-loading snippets in card templates, dialogs, and widgets with calls to the shared loader.

## Testing
- ⚠️ `pytest` *(fails: ModuleNotFoundError: No module named 'PySide6')*


------
https://chatgpt.com/codex/tasks/task_e_68bb8c057ca0832490c307acbb5b2782